### PR TITLE
Create `Generation` type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "cSpell.words": [
         "Bitstring",
+        "Bitstrings",
+        "esitsu",
         "hiff",
         "rngs",
         "scottmcm's"

--- a/Planning.md
+++ b/Planning.md
@@ -11,6 +11,20 @@ Some things that we could/should deal with include:
 - I think we have the parent selection thing in a reasonable
   place, but still we need to work out pipelines of mutation
   and recombination operators.
+  - The addition of a closure that captures most of this pipeline
+    in the construction of a `Generation` type may essentially
+    resolve this issue, or at least suggests a way to approach it.
+- Extend `PopulationSelector` to a `WeightedParentSelector` that
+  is essentially a wrapper around `rand::distributions::WeightedChoice`
+  so we can provide weights on the different selectors.
+- Implement a non-threaded `Generation::next()` method that
+  creates a new generation without using the Rayon `into_par_iter()`.
+  - If we did this we could also benchmark both parallel and serial
+    versions of the system to see how much faster things run in
+    parallel.
+  - It would probably be reasonable to add a `parallel` feature
+    to the project so people could leave out parallelism (& Rayon)
+    if they didn't want any of that.
 
 ## Wednesday, 21 Sep 2022 (7-9pm)
 
@@ -26,5 +40,28 @@ we did last week:
   is essentially a wrapper around `rand::distributions::WeightedChoice`
   so we can provide weights on the different selectors.
 - If those get done quickly, then we can look at the problem of
-  pipelining mutation and recominbation operators.
-  
+  pipelining mutation and recombination operators.
+
+### What actually happened
+
+`esitsu@Twitch` suggested moving the `ParentSelector` logic into a new
+`Generation` type, which would then have a `next()` method to generate
+the next generation from the current one. We then spent pretty much the
+entire stream implementing this (good) idea.
+
+Most of it was pretty straightforward, but we got really bogged down at
+the end because of a problem with the Rust compiler's understanding of a
+closure's types.
+
+`esitsu` also had a really cool idea of extracting the bit string specific
+parts of the `next` generation logic into a closure that we'd pass in when
+we construct the generation. This worked, but I didn't explicitly type the
+arguments to the closure initially, and that let to all kinds of weird
+confusion. We flailed pretty hard trying to resolve the issues, doing all
+sorts of things with lifetimes. In the end it turned out that all we
+_really_ needed to do was explicitly type that closure, and once we did
+that everything worked.
+
+After the stream ended I removed the `next_generation()` logic and
+`ParentSelector` type from `Population`, moving the former into
+`Generation` and deleting the latter altogether.

--- a/Planning.md
+++ b/Planning.md
@@ -1,8 +1,12 @@
-# Rust-GA live stream planning
+# Rust-GA live stream planning <!-- omit in toc -->
 
 I'm going to use this to do some planning and documentation for the
 live stream. Not sure how well that will work out, but just putting
 `TODO`s in the code doesn't always provide any kind of "big picture".
+
+- [Issues to address](#issues-to-address)
+- [Wednesday, 21 Sep 2022 (7-9pm)](#wednesday-21-sep-2022-7-9pm)
+  - [What actually happened](#what-actually-happened)
 
 ## Issues to address
 

--- a/Planning.md
+++ b/Planning.md
@@ -25,6 +25,11 @@ Some things that we could/should deal with include:
   - It would probably be reasonable to add a `parallel` feature
     to the project so people could leave out parallelism (& Rayon)
     if they didn't want any of that.
+- Should the `scorer` be inside the generation so we don't have to
+  keep capturing it and passing it around?
+  - Or should there actually be a `Run` type (or a `RunParams` type)
+    that holds all this stuff and is used to make them available to
+    types like `Generation` and `Population`?
 
 ## Wednesday, 21 Sep 2022 (7-9pm)
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # rust-ga
+
+This is a simple (but pretty flexible) bit-string genetic algorithm
+in Rust so I can compare its performance to a similar system in
+Clojure.
+
+See [Planning.md](Planning.md) for info on where we're heading
+and what we've accomplished.

--- a/src/bitstring.rs
+++ b/src/bitstring.rs
@@ -116,7 +116,7 @@ impl Individual<Bitstring> {
 // TODO: I need to deal with the fact that this computes the score multiple times
 // if I chain things like mutation and crossover. This is related to the need to
 // parameterize the recombination operators, and I'll probably need to have some
-// kind of vector of recombination operatorss that act on the Bitstrings, and then
+// kind of vector of recombination operators that act on the Bitstrings, and then
 // computes the score once at the end.
 // 
 // An alternative would be to use the Lazy eval tools and say that the score of

--- a/src/bitstring.rs
+++ b/src/bitstring.rs
@@ -14,8 +14,10 @@ use crate::population::{Population, Selector};
 
 pub type Bitstring = Vec<bool>;
 
-trait LinearCrossover {
+pub trait LinearCrossover {
+    #[must_use]
     fn uniform_xo(&self, other: &Self, rng: &mut ThreadRng) -> Self;
+    #[must_use]
     fn two_point_xo(&self, other: &Self, rng: &mut ThreadRng) -> Self;
 }
 
@@ -48,8 +50,10 @@ impl<T: Copy> LinearCrossover for Vec<T> {
     }
 }
 
-trait LinearMutation {
+pub trait LinearMutation {
+    #[must_use]
     fn mutate_with_rate(&self, mutation_rate: f32, rng: &mut ThreadRng) -> Self;
+    #[must_use]
     fn mutate_one_over_length(&self, rng: &mut ThreadRng) -> Self;
 }
 
@@ -211,22 +215,6 @@ impl Population<Bitstring> {
             |rng| make_random(bit_length, rng),
             compute_score
         )
-    }
-
-    /// # Panics
-    /// 
-    /// Will panic if the population is empty.
-    #[must_use]
-    pub fn best_individual(&self) -> &Individual<Bitstring> {
-        assert!(!self.individuals.is_empty());
-        #[allow(clippy::unwrap_used)]
-        self
-            .individuals
-            .iter()
-            .max_by_key(
-                |ind| ind.score
-            )
-            .unwrap()
     }
 
     /// # Panics

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -47,6 +47,9 @@ impl<'a, T: Send + Sync> Generation<'a, T> {
         let individuals 
             = (0..pop_size)
                 .into_par_iter()
+                // "Convert" the individual number (which we never use) into
+                // the current `Generation` object so the `make_child` closure
+                // will have access to the selectors and population.
                 .map(|_| self)
                 .map_init(rand::thread_rng, self.make_child)
                 .collect();

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1,10 +1,14 @@
 use rand::{rngs::ThreadRng, seq::SliceRandom};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-use crate::{population::{Population, Selector}, individual::Individual};
+use crate::{population::{Population}, individual::Individual};
 
-type ChildMaker<T> = dyn Fn(&mut ThreadRng, &Generation<T>) -> Individual<T> + Send + Sync;
+pub type Selector<T> = dyn Fn(&Population<T>) -> Option<&Individual<T>> + Sync + Send;
+pub type ChildMaker<T> = dyn Fn(&mut ThreadRng, &Generation<T>) -> Individual<T> + Send + Sync;
 
+// TODO: Extend the vector of Selectors to a WeightedParentSelector that is essentially
+//   a wrapper around `rand::distributions::WeightedChoice` so we can
+//   provide weights on the different selectors.
 pub struct Generation<'a, T> {
     pub population: Population<T>,
     selectors: &'a Vec<&'a Selector<T>>,

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1,0 +1,57 @@
+use rand::{rngs::ThreadRng, seq::SliceRandom};
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+
+use crate::{population::{Population, Selector}, individual::Individual};
+
+type ChildMaker<T> = dyn Fn(&mut ThreadRng, &Generation<T>) -> Individual<T> + Send + Sync;
+
+pub struct Generation<'a, T> {
+    pub population: Population<T>,
+    selectors: &'a Vec<&'a Selector<T>>,
+    make_child: &'a ChildMaker<T>
+}
+
+impl<'a, T> Generation<'a, T> {
+    pub fn new(population: Population<T>, selectors: &'a Vec<&Selector<T>>, make_child: &'a ChildMaker<T>) -> Self {
+        assert!(!population.is_empty());
+        assert!(!selectors.is_empty());
+        Self {
+            population,
+            selectors,
+            make_child
+        }
+    }
+
+    pub fn best_individual(&self) -> &Individual<T> {
+        self.population.best_individual()
+    }
+
+    pub fn get_parent(&self, rng: &mut ThreadRng) -> &Individual<T> {
+        // The set of selectors should be non-empty, and if it is, then we
+        // should be able to safely unwrap the `choose()` call.
+        let s = self.selectors.choose(rng).unwrap();
+        // The population should be non-empty, and if it is, then we should be
+        // able to safely unwrap the selection call.
+        s(&self.population).unwrap()
+    }
+}
+
+impl<'a, T: Send + Sync> Generation<'a, T> {
+    pub fn par_next(&self) -> Self {
+        let previous_individuals = &self.population.individuals;
+        let pop_size = previous_individuals.len();
+        let individuals 
+            = (0..pop_size)
+                .into_par_iter()
+                .map(|_| self)
+                .map_init(rand::thread_rng, self.make_child)
+                .collect();
+        Self { 
+            population: Population { individuals },
+            selectors: self.selectors,
+            make_child: self.make_child
+        }
+    }
+
+    // TODO: Create a `next()` that doesn't use parallelism, i.e., skips the `into_par_iter()` bit.
+}

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -9,6 +9,11 @@ pub type ChildMaker<T> = dyn Fn(&mut ThreadRng, &Generation<T>) -> Individual<T>
 // TODO: Extend the vector of Selectors to a WeightedParentSelector that is essentially
 //   a wrapper around `rand::distributions::WeightedChoice` so we can
 //   provide weights on the different selectors.
+// TODO: Should the `scorer` be inside the generation so we don't have to keep
+//   capturing it and passing it around?
+// TODO: Should there actually be a `Run` type (or a `RunParams` type) that
+//   holds all this stuff and is used to make them available to types like
+//   `Generation` and `Population`?
 pub struct Generation<'a, T> {
     pub population: Population<T>,
     selectors: &'a Vec<&'a Selector<T>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,15 +27,7 @@ pub fn do_main() {
     assert!(!population.is_empty());
 
     let make_child = move |rng: &mut ThreadRng, generation: &Generation<Bitstring>| {
-            let first_parent = generation.get_parent(rng);
-            let second_parent = generation.get_parent(rng);
-
-            let genome
-                = first_parent.genome
-                .two_point_xo(&second_parent.genome, rng)
-                .mutate_one_over_length(rng);
-            let score = scorer(&genome);
-            Individual { genome, score }
+        make_child(scorer, rng, generation)
     };
 
     let mut generation = Generation::new(
@@ -55,4 +47,16 @@ pub fn do_main() {
         let best = generation.best_individual();
         println!("Generation {} best is {:?}", generation_number, best);
     });
+}
+
+fn make_child(scorer: impl Fn(&[bool]) -> i64, rng: &mut ThreadRng, generation: &Generation<Bitstring>) -> Individual<Bitstring> {
+    let first_parent = generation.get_parent(rng);
+    let second_parent = generation.get_parent(rng);
+
+    let genome
+        = first_parent.genome
+            .two_point_xo(&second_parent.genome, rng)
+            .mutate_one_over_length(rng);
+    let score = scorer(&genome);
+    Individual { genome, score }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,17 @@
-use crate::{bitstring::{hiff, Bitstring}, population::{Population, Selector}};
+use rand::rngs::ThreadRng;
+
+use crate::{bitstring::{hiff, Bitstring, LinearCrossover, LinearMutation}, population::{Population, Selector}, generation::Generation, individual::Individual};
 
 pub mod individual;
 pub mod population;
+pub mod generation;
 pub mod bitstring;
 
 pub fn do_main() {
     let scorer = hiff;
-    let mut population
-        = Population::new_bitstring_population(
-            1000, 
-            128, 
-            scorer);
-    assert!(!population.individuals.is_empty());
-    #[allow(clippy::unwrap_used)]
-    let best = population.best_individual();
-    println!("{:?}", best);
-    println!("Pop size = {}", population.individuals.len());
-    println!("Bit length = {}", best.genome.len());
 
     let binary_tournament = Population::<Bitstring>::make_tournament_selector(2);
     let decimal_tournament = Population::<Bitstring>::make_tournament_selector(10);
-
     let selectors: Vec<&Selector<Bitstring>> 
         = vec![&Population::best_score,
                &Population::random, 
@@ -28,11 +19,45 @@ pub fn do_main() {
                &binary_tournament,
                &decimal_tournament];
 
-    (0..100).for_each(|generation| {
-        population = population.next_generation_with_selectors(&selectors, scorer);
-        let best = population.best_individual();
-        println!("Generation {} best is {:?}", generation, best);
-        println!("Pop size = {}", population.individuals.len());
-        println!("Bit length = {}", best.genome.len());
+    let population
+        = Population::new_bitstring_population(
+            1000, 
+            128, 
+            scorer);
+    assert!(!population.is_empty());
+
+    let make_child = move |rng: &mut ThreadRng, generation: &Generation<Bitstring>| {
+            // These two `unwrap()`s are OK because we've asserted that the set of selectors
+            // isn't empty.
+            #[allow(clippy::unwrap_used)]
+            let first_parent = generation.get_parent(rng); // parent_selector.get(rng).unwrap();
+            #[allow(clippy::unwrap_used)]
+            let second_parent = generation.get_parent(rng); // parent_selector.get(rng).unwrap();
+
+            let genome
+                = first_parent.genome
+                .two_point_xo(&second_parent.genome, rng)
+                .mutate_one_over_length(rng);
+            let score = scorer(&genome);
+            Individual { genome, score }
+            // todo!()
+    };
+
+    let mut generation = Generation::new(
+        population,
+        &selectors,
+        &make_child
+    );
+
+    assert!(!generation.population.is_empty());
+    let best = generation.best_individual();
+    println!("{:?}", best);
+    println!("Pop size = {}", generation.population.size());
+    println!("Bit length = {}", best.genome.len());
+
+    (0..100).for_each(|generation_number| {
+        generation = generation.par_next();
+        let best = generation.best_individual();
+        println!("Generation {} best is {:?}", generation_number, best);
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,8 @@ pub fn do_main() {
     assert!(!population.is_empty());
 
     let make_child = move |rng: &mut ThreadRng, generation: &Generation<Bitstring>| {
-            // These two `unwrap()`s are OK because we've asserted that the set of selectors
-            // isn't empty.
-            #[allow(clippy::unwrap_used)]
-            let first_parent = generation.get_parent(rng); // parent_selector.get(rng).unwrap();
-            #[allow(clippy::unwrap_used)]
-            let second_parent = generation.get_parent(rng); // parent_selector.get(rng).unwrap();
+            let first_parent = generation.get_parent(rng);
+            let second_parent = generation.get_parent(rng);
 
             let genome
                 = first_parent.genome
@@ -40,7 +36,6 @@ pub fn do_main() {
                 .mutate_one_over_length(rng);
             let score = scorer(&genome);
             Individual { genome, score }
-            // todo!()
     };
 
     let mut generation = Generation::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use rand::rngs::ThreadRng;
 
-use crate::{bitstring::{hiff, Bitstring, LinearCrossover, LinearMutation}, population::{Population, Selector}, generation::Generation, individual::Individual};
+use crate::{bitstring::{hiff, Bitstring, LinearCrossover, LinearMutation}, population::Population, generation::{Generation, Selector}, individual::Individual};
 
 pub mod individual;
 pub mod population;

--- a/src/population.rs
+++ b/src/population.rs
@@ -44,6 +44,34 @@ impl<T: Send> Population<T> {
     }
 }
 
+impl<T> Population<T> {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.individuals.is_empty()
+    }
+
+    #[must_use]
+    pub fn size(&self) -> usize {
+        self.individuals.len()
+    }
+
+    /// # Panics
+    /// 
+    /// Will panic if the population is empty.
+    #[must_use]
+    pub fn best_individual(&self) -> &Individual<T> {
+        assert!(!self.individuals.is_empty());
+        #[allow(clippy::unwrap_used)]
+        self
+            .individuals
+            .iter()
+            .max_by_key(
+                |ind| ind.score
+            )
+            .unwrap()
+    }
+}
+
 pub type Selector<T> = dyn Fn(&Population<T>) -> Option<&Individual<T>> + Sync + Send;
 
 // TODO: Should this just become part of the `Population` type?

--- a/src/population.rs
+++ b/src/population.rs
@@ -73,45 +73,6 @@ impl<T> Population<T> {
 }
 
 pub type Selector<T> = dyn Fn(&Population<T>) -> Option<&Individual<T>> + Sync + Send;
-
-// TODO: Should this just become part of the `Population` type?
-//   We could provide a set of selectors in the constructor (or
-//   a builder) for `Population`, and then just have a `get_parent()`
-//   method there.
-// TODO: Extend this to a WeightedParentSelector that is essentially
-//   a wrapper around `rand::distributions::WeightedChoice` so we can
-//   provide weights on the different selectors.
-pub struct ParentSelector<'a, T> {
-    population: &'a Population<T>,
-    selectors: &'a Vec<&'a Selector<T>>,
-}
-
-impl<'a, T> ParentSelector<'a, T> {
-    fn new(population: &'a Population<T>, selectors: &'a Vec<&'a Selector<T>>) -> Self {
-        ParentSelector {
-            population,
-            selectors
-        }
-    }
-
-    pub fn get(&self, rng: &mut ThreadRng) -> Option<&'a Individual<T>> {
-        let s = self.selectors.choose(rng)?;
-        s(self.population)
-    }
-}
-
-impl<T> Population<T> {
-    // TODO: This iterator is sequential, and we might want it to become parallel,
-    // if that is feasible. I'll need to better understand how to implement Rayon's
-    // parallel iterator trait.
-    #[must_use]
-    pub fn parent_selector<'a>(&'a self, selectors: &'a Vec<&'a Selector<T>>) -> ParentSelector<T> {
-        // TODO: We might want or need to move this somewhere else if we convert
-        // to parallel iterators.
-        ParentSelector::new(self, selectors)
-    }
-}
-
 impl<T> Population<T> {
     /// # Panics
     ///

--- a/src/population.rs
+++ b/src/population.rs
@@ -72,7 +72,6 @@ impl<T> Population<T> {
     }
 }
 
-pub type Selector<T> = dyn Fn(&Population<T>) -> Option<&Individual<T>> + Sync + Send;
 impl<T> Population<T> {
     /// # Panics
     ///


### PR DESCRIPTION
`esitsu@Twitch` suggested creating a `Generation` type that wraps a population and is in charge of things like selection and recombination. That sounded like a good idea, so we spent most of the 21 Sep 2022 stream getting that to work.

I also created a new `Planning.md` document to keep track of plans, goals, and what's happened. Should have been doing this on all the live streaming repos from the beginning.