### PR TITLE
Add serial `Generation::next()`, command line arguments, and extend benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,8 +62,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap 0.15.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -74,7 +113,7 @@ checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -193,12 +232,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -299,6 +360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "plotters"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +398,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -429,6 +520,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 name = "rust_ga"
 version = "0.1.0"
 dependencies = [
+ "clap 3.2.22",
  "criterion",
  "rand",
  "rayon",
@@ -494,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +619,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "tinytemplate"
@@ -534,6 +647,12 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "3.2.22", features = ["derive"] }
 rand = "0.8.5"
 rayon = "1.5.3"
 

--- a/Planning.md
+++ b/Planning.md
@@ -28,6 +28,10 @@ particular order.
 
 ### Use `clap` to support command-line args for parameters
 
+> 25 Sep 2022: I've added support for most of this. The one thing
+> I don't have any command line support for yet is the selectors
+> and the mutation/recombination pipelines.
+
 Using `clap` in [the Rust echo client-server](https://github.com/NicMcPhee/rust-echo-client-server)
 was really easy, and worked quite nicely. We should add `clap`
 support for the various parameters that we might want to

--- a/Planning.md
+++ b/Planning.md
@@ -17,7 +17,6 @@ Issues might make more sense.
   - [Replace `Individual` with traits?](#replace-individual-with-traits)
   - [Create mutation/recombination pipeline](#create-mutationrecombination-pipeline)
   - [Supported weighted parent selection](#supported-weighted-parent-selection)
-  - [Implement non-threaded `Generation::next()`](#implement-non-threaded-generationnext)
   - [Move `scorer` inside `Generation`?](#move-scorer-inside-generation)
 - [Wednesday, 21 Sep 2022 (7-9pm)](#wednesday-21-sep-2022-7-9pm)
   - [What actually happened](#what-actually-happened)
@@ -106,19 +105,6 @@ resolve this issue, or at least suggests a way to approach it.
 We should extend `PopulationSelector` to a `WeightedParentSelector` that
 is essentially a wrapper around `rand::distributions::WeightedChoice`
 so we can provide weights on the different selectors.
-
-### Implement non-threaded `Generation::next()`
-
-We should probably implement a non-threaded `Generation::next()`
-method that creates a new generation without using the Rayon `into_par_iter()`.
-
-If we did this we could also benchmark both parallel and serial
-versions of the system to see how much faster things run in
-parallel.
-
-It would might also be reasonable to add a `parallel` feature
-to the project so people could leave out parallelism (& Rayon)
-if they didn't want any of that.
 
 ### Move `scorer` inside `Generation`?
 

--- a/benches/construction_benchmark.rs
+++ b/benches/construction_benchmark.rs
@@ -1,6 +1,19 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use rust_ga::{population::Population, bitstring::{count_ones, hiff}, do_main};
+use rust_ga::{
+    population::Population, 
+    bitstring::{count_ones, hiff}, 
+    do_main, 
+    args::{TargetProblem, Args, RunModel}
+};
+
+const DEFAULT_ARGS: Args = Args {
+    run_model: RunModel::Parallel,
+    target_problem: TargetProblem::Hiff,
+    population_size: 1000,
+    bit_length: 128,
+    num_generations: 100,
+};
 
 fn benchmark_construction_count_ones(c: &mut Criterion) {
     c.bench_function(
@@ -24,47 +37,62 @@ fn benchmark_construction_hiff(c: &mut Criterion) {
     ));
 }
 
-fn benchmark_main_hiff(c: &mut Criterion) {
+fn benchmark_run_count_ones_serial(c: &mut Criterion) {
+    let args = Args {
+        run_model: RunModel::Serial,
+        target_problem: TargetProblem::CountOnes,
+        ..DEFAULT_ARGS
+    };
     c.bench_function(
-        "Run main() on HIFF", 
-        |b| b.iter(|| do_main())
+        "Run main() serially on Count Ones", 
+        |b| b.iter(|| {
+            do_main(black_box(args))
+        })
+    );
+}
+
+fn benchmark_run_count_ones_parallel(c: &mut Criterion) {
+    let args = Args {
+        run_model: RunModel::Parallel,
+        target_problem: TargetProblem::CountOnes,
+        ..DEFAULT_ARGS
+    };
+    c.bench_function(
+        "Run main() in parallel on Count Ones", 
+        |b| b.iter(|| {
+            do_main(black_box(args))
+        })
+    );
+}
+
+fn benchmark_run_hiff_serial(c: &mut Criterion) {
+    let args = Args {
+        run_model: RunModel::Serial,
+        target_problem: TargetProblem::Hiff,
+        ..DEFAULT_ARGS
+    };
+    c.bench_function(
+        "Run main() serially on HIFF", 
+        |b| b.iter(|| {
+            do_main(black_box(args))
+        })
+    );
+}
+
+fn benchmark_run_hiff_parallel(c: &mut Criterion) {
+    let args = Args {
+        run_model: RunModel::Parallel,
+        target_problem: TargetProblem::Hiff,
+        ..DEFAULT_ARGS
+    };
+    c.bench_function(
+        "Run main() in parallel on HIFF", 
+        |b| b.iter(|| {
+            do_main(black_box(args))
+        })
     );
 }
 
 criterion_group!(construction_benches, benchmark_construction_count_ones, benchmark_construction_hiff);
-criterion_group!(main_benches, benchmark_main_hiff);
+criterion_group!(main_benches, benchmark_run_count_ones_serial, benchmark_run_count_ones_parallel, benchmark_run_hiff_serial, benchmark_run_hiff_parallel);
 criterion_main!(main_benches);
-
-
-
-
-    // #[bench]
-    // fn bench_count_ones(b: &mut Bencher) {
-    //     let mut rng = StdRng::seed_from_u64(0);
-    //     b.iter(|| {
-    //         let bits = vec![rng.gen_bool(0.5); 128];
-    //         count_ones(&bits)
-    //     });
-    // }
-
-    // #[bench]
-    // fn bench_individual_new(b: &mut Bencher) {
-    //     let mut rng = StdRng::seed_from_u64(0);
-    //     b.iter(|| Individual::new(128, &mut rng));
-    // }
-
-    // #[bench]
-    // fn bench_population_new(b: &mut Bencher) {
-    //     let mut rng = StdRng::seed_from_u64(0);
-    //     b.iter(|| Population::new(100, 128, &mut rng));
-    // }
-
-    // #[bench]
-    // fn bench_population_iter(b: &mut Bencher) {
-    //     let population = Population::new(100, 128, &mut rand::thread_rng());
-    //     b.iter(|| {
-    //         for ind in population.individuals.iter() {
-    //             ind.fitness
-    //         }
-    //     });
-    // }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,19 +1,19 @@
 use clap::Parser;
 
-#[derive(clap::ValueEnum, Clone, Debug)]
+#[derive(clap::ValueEnum, Copy, Clone, Debug)]
 pub enum RunModel {
     Serial,
     Parallel
 }
 
-#[derive(clap::ValueEnum, Clone, Debug)]
+#[derive(clap::ValueEnum, Copy, Clone, Debug)]
 pub enum TargetProblem {
     CountOnes,
     Hiff
 }
 
 /// Simple genetic algorithm in Rust
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Copy, Clone)]
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
     /// Should we use parallelism when doing the run?

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,38 @@
+use clap::Parser;
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum RunModel {
+    Serial,
+    Parallel
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum TargetProblem {
+    CountOnes,
+    Hiff
+}
+
+/// Simple genetic algorithm in Rust
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// Should we use parallelism when doing the run?
+    #[clap(short, long, value_enum, default_value_t = RunModel::Parallel)]
+    pub run_model: RunModel,
+
+    /// The target problem to run
+    #[clap(short, long, value_enum, default_value_t = TargetProblem::Hiff)]
+    pub target_problem: TargetProblem,
+
+    /// Population size
+    #[clap(short, long, value_parser, default_value_t = 100)]
+    pub population_size: usize,
+
+    /// Number of bits in bit strings
+    #[clap(short, long, value_parser, default_value_t = 128)]
+    pub bit_length: usize,
+
+    /// Number of generations to run
+    #[clap(short, long, value_parser, default_value_t = 100)]
+    pub num_generations: usize,
+}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,10 +3,14 @@
 #![warn(clippy::unwrap_used)]
 #![warn(clippy::expect_used)]
 
+use clap::{Parser};
+use rust_ga::args::Args;
 use rust_ga::do_main;
 
 fn main() {
-    do_main();
+    let args = Args::parse();
+
+    do_main(args);
 }
 
 #[cfg(test)]

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -46,6 +46,7 @@ impl<'a, T> Generation<'a, T> {
 }
 
 impl<'a, T: Send + Sync> Generation<'a, T> {
+    /// Make the next generation using a Rayon parallel iterator.
     pub fn par_next(&self) -> Self {
         let previous_individuals = &self.population.individuals;
         let pop_size = previous_individuals.len();
@@ -65,5 +66,19 @@ impl<'a, T: Send + Sync> Generation<'a, T> {
         }
     }
 
-    // TODO: Create a `next()` that doesn't use parallelism, i.e., skips the `into_par_iter()` bit.
+    /// Make the next generation serially.
+    pub fn next(&self) -> Self {
+        let previous_individuals = &self.population.individuals;
+        let pop_size = previous_individuals.len();
+        let mut rng = rand::thread_rng();
+        let individuals 
+            = (0..pop_size)
+                .map(|_| (self.make_child)(&mut rng, self))
+                .collect();
+        Self { 
+            population: Population { individuals },
+            selectors: self.selectors,
+            make_child: self.make_child
+        }
+    }
 }


### PR DESCRIPTION
This adds a serial `Generation::next()` method so we can do runs serially as well as in parallel. 

I also at least started adding command line arguments using the `clap` crate. There's nothing here yet for selectors or the mutation/recombination pipeline. There's sort of support for the target problem, but you have to choose from a fairly small set of fixed options (just Count Ones and HIFF).

I used these to extend the benchmarking so we can benchmark full runs in four ways (serial vs. parallel, Count Ones vs. HIFF).