### PR TITLE
Add GitHub ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component ${{ matrix.toolchain }} add clippy
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy
       - run: cargo build --verbose
       - run: cargo test --verbose
       - run: cargo clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: rust-ga - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+      - run: cargo clippy
+      - run: cargo fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy && rustup component add rustfmt
       - run: cargo build --verbose
       - run: cargo test --verbose
       - run: cargo clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component ${{ matrix.toolchain }} add clippy
       - run: cargo build --verbose
       - run: cargo test --verbose
       - run: cargo clippy

--- a/packages/ec-core/src/generator/collection.rs
+++ b/packages/ec-core/src/generator/collection.rs
@@ -29,6 +29,13 @@ where
     C: Generator<T>,
 {
     fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<Vec<T>> {
+        // Doing some reading, I _think_ this will properly pre-allocate an appropriately sized
+        // `Vec` to collect into. https://users.rust-lang.org/t/collect-for-exactsizediterator/54367/2
+        // says, for example, that collecting into a `Vec` will pre-allocate to the minimum returned
+        // by `type_hints`. Looking at the code, it seems that `repeat_with` returns "infinity" for the
+        // minimum size, and `take` returns the `min` of `self.size` and the minimum size from the
+        // preceding iterator (infinity). This will always be `self.size`, which is just what we'd
+        // want the size allocation to be.
         repeat_with(|| self.element_generator.generate(rng))
             .take(self.size)
             .collect()

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -315,7 +315,7 @@ impl<T> Stack<T> {
     ///
     /// # Arguments
     ///
-    /// * `values` - An implementation of [`IntoIterator`] which
+    /// - `values` - An implementation of [`IntoIterator`] which
     /// must also implement both [`ExactSizeIterator`] and
     /// [`DoubleEndedIterator`]. `values` can be, for example,
     /// any collection of items of type `T` that can be converted


### PR DESCRIPTION
This is arguably pretty aggressive. I think it will straight up fail if either `cargo clippy` or `cargo fmt --check` fail, which might be more than we want. I figured I'd start with a very strict version, and then we can relax things later.

This closes #19 