### PR TITLE
Genericize score and error

### DIFF
--- a/packages/ec-core/src/generator/collection.rs
+++ b/packages/ec-core/src/generator/collection.rs
@@ -29,6 +29,13 @@ where
     C: Generator<T>,
 {
     fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<Vec<T>> {
+        // Doing some reading, I _think_ this will properly pre-allocate an appropriately sized
+        // `Vec` to collect into. https://users.rust-lang.org/t/collect-for-exactsizediterator/54367/2
+        // says, for example, that collecting into a `Vec` will pre-allocate to the minimum returned
+        // by `type_hints`. Looking at the code, it seems that `repeat_with` returns "infinity" for the
+        // minimum size, and `take` returns the `min` of `self.size` and the minimum size from the
+        // preceding iterator (infinity). This will always be `self.size`, which is just what we'd
+        // want the size allocation to be.
         repeat_with(|| self.element_generator.generate(rng))
             .take(self.size)
             .collect()

--- a/packages/ec-ga-cli/src/main.rs
+++ b/packages/ec-ga-cli/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
     // Using `Error` in `TestResults<Error>` will have the run favor smaller
     // values, where using `Score` (e.g., `TestResults<Score>`) will have the run
     // favor larger values.
-    type Pop = Vec<EcIndividual<Bitstring, TestResults<test_results::Score>>>;
+    type Pop = Vec<EcIndividual<Bitstring, TestResults<test_results::Score<i64>>>>;
 
     let args = Args::parse();
 

--- a/packages/ec-linear/src/genome/demo_scorers.rs
+++ b/packages/ec-linear/src/genome/demo_scorers.rs
@@ -1,7 +1,7 @@
 use ec_core::test_results::{self, TestResults};
 
 #[must_use]
-pub fn count_ones(bits: &[bool]) -> TestResults<test_results::Score> {
+pub fn count_ones(bits: &[bool]) -> TestResults<test_results::Score<i64>> {
     bits.iter().map(|bit| i64::from(*bit)).collect()
 }
 
@@ -13,7 +13,7 @@ pub fn count_ones(bits: &[bool]) -> TestResults<test_results::Score> {
 /// it's necessary that the length fit in an `i64`. If it doesn't we'll
 /// panic here.
 #[must_use]
-pub fn hiff(bits: &[bool]) -> TestResults<test_results::Score> {
+pub fn hiff(bits: &[bool]) -> TestResults<test_results::Score<i64>> {
     // Since the scores are represented as `i64`, and the largest
     // possible score is the length of `bits`, we need to know that
     // `bits.len()` can fit in an `i64`. If this is true we can use
@@ -59,15 +59,10 @@ mod test_count_ones {
     use super::count_ones;
 
     #[test]
-    fn empty() {
-        let empty_vec: TestResults<test_results::Score> = Vec::new().iter().collect();
-        assert_eq!(empty_vec, count_ones(&[]));
-    }
-
-    #[test]
     fn non_empty() {
         let input = [false, true, true, true, false, true];
-        let output: TestResults<test_results::Score> = [0, 1, 1, 1, 0, 1].iter().collect();
+        let output: TestResults<test_results::Score<i64>> =
+            [0, 1, 1, 1, 0, 1].into_iter().collect();
         assert_eq!(output, count_ones(&input));
     }
 }

--- a/packages/ec-push-cli/src/main.rs
+++ b/packages/ec-push-cli/src/main.rs
@@ -5,6 +5,8 @@
 
 pub mod args;
 
+use std::ops::Not;
+
 use crate::args::{Args, RunModel};
 use anyhow::{ensure, Result};
 use clap::Parser;
@@ -32,13 +34,12 @@ use push::{
     push_vm::{HasStack, PushInteger},
 };
 use rand::thread_rng;
-use std::ops::Not;
 
 fn main() -> Result<()> {
     // Using `Error` in `TestResults<Error>` will have the run favor smaller
     // values, where using `Score` (e.g., `TestResults<Score>`) will have the run
     // favor larger values.
-    type Pop = Vec<EcIndividual<Plushy, TestResults<test_results::Error>>>;
+    type Pop = Vec<EcIndividual<Plushy, TestResults<test_results::Error<i64>>>>;
 
     // The penalty value to use when an evolved program doesn't have an expected
     // "return" value on the appropriate stack at the end of its execution.
@@ -57,8 +58,8 @@ fn main() -> Result<()> {
      *
      * The target polynomial is x^3 - 2x^2 - x
      */
-    let scorer = |program: &Plushy| -> TestResults<test_results::Error> {
-        let errors: TestResults<test_results::Error> = (0..10)
+    let scorer = |program: &Plushy| -> TestResults<test_results::Error<i64>> {
+        let errors: TestResults<test_results::Error<i64>> = (0..10)
             .map(|input| {
                 #[allow(clippy::unwrap_used)]
                 let state = PushState::builder()
@@ -139,8 +140,8 @@ fn main() -> Result<()> {
 
     let mut generation = Generation::new(make_new_individual, population);
 
-    // // TODO: It might be useful to insert some kind of logging system so we can
-    // //   make this less imperative in nature.
+    // TODO: It might be useful to insert some kind of logging system so we can
+    //   make this less imperative in nature.
 
     for generation_number in 0..args.num_generations {
         match args.run_model {

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -315,7 +315,7 @@ impl<T> Stack<T> {
     ///
     /// # Arguments
     ///
-    /// * `values` - An implementation of [`IntoIterator`] which
+    /// - `values` - An implementation of [`IntoIterator`] which
     /// must also implement both [`ExactSizeIterator`] and
     /// [`DoubleEndedIterator`]. `values` can be, for example,
     /// any collection of items of type `T` that can be converted

--- a/packages/rust-lexicase/src/lib.rs
+++ b/packages/rust-lexicase/src/lib.rs
@@ -15,7 +15,7 @@ use rand::thread_rng;
 
 struct PyIndividual {
     individual: PyObject,
-    errors: TestResults<Error>,
+    errors: TestResults<Error<i64>>,
 }
 
 impl PyIndividual {
@@ -27,7 +27,7 @@ impl PyIndividual {
             .into_iter()
             .copied()
             .map(|v| Error { error: v })
-            .collect::<TestResults<Error>>();
+            .collect::<TestResults<Error<i64>>>();
         Ok(Self { individual, errors })
     }
 
@@ -39,7 +39,7 @@ impl PyIndividual {
 impl Individual for PyIndividual {
     type Genome = Self;
 
-    type TestResults = TestResults<Error>;
+    type TestResults = TestResults<Error<i64>>;
 
     fn genome(&self) -> &Self::Genome {
         unimplemented!()


### PR DESCRIPTION
This makes both the `Score` and `Error` types generic in some type `T` instead of having them both hard-coded to be `i64` values.

This also make `TestResult` generic in two types, one for errors and one for scores. Not entirely sure if we'll ever use that, but it seemed a potentially nice piece of flexibility.

When switching from `i64`, which is `Clone + Copy` to generic `T`, we didn't want to assume the ability to `Clone` or `Copy`, so we changed summation over references to require `T: ToOwned` so we could use `.to_owned()` to convert references to owned types.

We also removed the `From<&T>` impls. They weren't being used, and getting them to work would require adding constraints on `T` that didn't seem necessary or desirable at this point. Callers should call `.copy()`/`.copied()`, or `.clone()`/`.cloned()`, as appropriate beforehand. See the `create_test_results...` tests for examples of this.

There were initially no tests for `PartialOrd` for `Score` or `Error`, so we added some.