### PR TITLE
 Remove the `PushInteger` type

### DIFF
--- a/packages/ec-core/src/operator/selector/lexicase.rs
+++ b/packages/ec-core/src/operator/selector/lexicase.rs
@@ -86,7 +86,7 @@ where
 
         candidates.shuffle(rng);
         candidates
-            .get(0)
+            .first()
             .copied()
             .context("The pool of candidates was empty")
     }

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -66,6 +66,14 @@ impl Bitstring {
         }
         .generate(rng)
     }
+
+    pub fn iter(&self) -> std::slice::Iter<bool> {
+        self.bits.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<bool> {
+        self.bits.iter_mut()
+    }
 }
 
 impl Display for Bitstring {

--- a/packages/ec-push-cli/src/main.rs
+++ b/packages/ec-push-cli/src/main.rs
@@ -30,8 +30,8 @@ use ec_linear::mutator::umad::Umad;
 use push::{
     genome::plushy::Plushy,
     instruction::{IntInstruction, PushInstruction, VariableName},
+    push_vm::HasStack,
     push_vm::{push_state::PushState, State},
-    push_vm::{HasStack, PushInteger},
 };
 use rand::thread_rng;
 
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
                 #[allow(clippy::option_if_let_else)]
                 match state.run_to_completion() {
                     Ok(final_state) => final_state
-                        .stack::<PushInteger>()
+                        .stack::<i64>()
                         .top()
                         .map_or(PENALTY_VALUE, |answer| (answer - expected).abs()),
                     Err(_) => {

--- a/packages/push-macros/src/push_state/printing/generate_builder.rs
+++ b/packages/push-macros/src/push_state/printing/generate_builder.rs
@@ -160,14 +160,13 @@ pub fn generate_builder(
                         /// # use push::push_vm::stack::Stack;
                         /// # use push::push_vm::stack::StackError;
                         /// # use push::push_vm::HasStack;
-                        /// # use push::push_vm::PushInteger;
                         ///
                         /// let mut state = PushState::builder()
                         ///     .with_max_stack_size(100)
                         ///     .with_program([])?
                         ///     .with_int_values(vec![5, 8, 9])?
                         ///     .build();
-                        /// let int_stack: &Stack<PushInteger> = state.stack::<PushInteger>();
+                        /// let int_stack: &Stack<i64> = state.stack::<i64>();
                         /// assert_eq!(int_stack.size(), 3);
                         /// // Now the top of the stack is 5, followed by 8, then 9 at the bottom.
                         /// assert_eq!(int_stack.top()?, &5);

--- a/packages/push/src/error/mod.rs
+++ b/packages/push/src/error/mod.rs
@@ -33,7 +33,7 @@ impl<S, E> Error<S, E> {
         matches!(self, Self::Fatal(_))
     }
 
-    pub fn state(&self) -> &S {
+    pub const fn state(&self) -> &S {
         match self {
             Self::Recoverable(StatefulError { state, .. })
             | Self::Fatal(StatefulError { state, .. }) => state,

--- a/packages/push/src/instruction/bool.rs
+++ b/packages/push/src/instruction/bool.rs
@@ -1,10 +1,7 @@
 use super::{Instruction, MapInstructionError, PushInstruction, PushInstructionError};
 use crate::{
     error::InstructionResult,
-    push_vm::{
-        stack::{HasStack, StackPush},
-        PushInteger,
-    },
+    push_vm::stack::{HasStack, StackPush},
 };
 use std::ops::Not;
 use strum_macros::EnumIter;
@@ -56,7 +53,7 @@ where
     let string = transaction.try_pop<String>()?; // This version has the transaction be mutable.
     let (string, transaction) = transaction.try_pop<String>()?; // This version returns a "new" transaction.
 
-    let (index, transaction) = transaction.try_pop<PushInteger>()?;
+    let (index, transaction) = transaction.try_pop<i64>()?;
     let c = string.chars.nth(index)?;
     let transaction = transaction.try_push<char>(c)?;
     let new_state = transaction.close()?; // Can closing actually fail?
@@ -98,7 +95,7 @@ where
             Self::FromInt => {
                 let mut state = state.not_full::<bool>().map_err_into()?;
                 state
-                    .stack_mut::<PushInteger>()
+                    .stack_mut::<i64>()
                     .pop()
                     .map(|i| i != 0)
                     .with_stack_push(state)

--- a/packages/push/src/instruction/float.rs
+++ b/packages/push/src/instruction/float.rs
@@ -78,7 +78,7 @@ where
                     state.stack_mut::<OrderedFloat<f64>>();
                 float_stack
                     .top()
-                    .map_err(Into::<PushInstructionError>::into)
+                    .map_err(PushInstructionError::from)
                     .cloned()
                     .with_stack_push(state)
             }
@@ -97,7 +97,7 @@ impl FloatInstruction {
         let float_stack = state.stack_mut::<OrderedFloat<f64>>();
         float_stack
             .top2()
-            .map_err(Into::<PushInstructionError>::into)
+            .map_err(PushInstructionError::from)
             .map(|(&x, &y)| op(x, y))
             .with_stack_replace(2, state)
     }
@@ -118,7 +118,7 @@ impl FloatInstruction {
         let float_stack: &mut Stack<OrderedFloat<f64>> = state.stack_mut::<OrderedFloat<f64>>();
         float_stack
             .top2()
-            .map_err(Into::<PushInstructionError>::into)
+            .map_err(PushInstructionError::from)
             .map(|(x, y)| op(x, y))
             .with_stack_push(state)
             .with_stack_discard::<OrderedFloat<f64>>(1)

--- a/packages/push/src/instruction/mod.rs
+++ b/packages/push/src/instruction/mod.rs
@@ -2,7 +2,7 @@ use ordered_float::OrderedFloat;
 
 use crate::{
     error::{Error, InstructionResult},
-    push_vm::{push_state::PushState, stack::StackError, HasStack, PushInteger},
+    push_vm::{push_state::PushState, stack::StackError, HasStack},
 };
 use std::{fmt::Debug, fmt::Display, sync::Arc};
 
@@ -170,7 +170,7 @@ impl PushInstruction {
     }
 
     #[must_use]
-    pub fn push_int(i: PushInteger) -> Self {
+    pub fn push_int(i: i64) -> Self {
         IntInstruction::Push(i).into()
     }
 

--- a/packages/push/src/push_vm/mod.rs
+++ b/packages/push/src/push_vm/mod.rs
@@ -8,9 +8,6 @@ pub mod stack;
 
 pub use self::stack::HasStack;
 
-// We'll use a 64-bit integer for our integer types.
-pub type PushInteger = i64;
-
 // Need an associated error trait
 pub trait State: Sized {
     type Instruction: Instruction<Self>;

--- a/packages/push/src/push_vm/push_state.rs
+++ b/packages/push/src/push_vm/push_state.rs
@@ -3,7 +3,7 @@ use ordered_float::OrderedFloat;
 use crate::{
     error::{stateful::FatalError, try_recover::TryRecover, InstructionResult},
     instruction::{Instruction, PushInstruction, PushInstructionError, VariableName},
-    push_vm::{stack::Stack, PushInteger, State},
+    push_vm::{stack::Stack, State},
 };
 use std::collections::HashMap;
 
@@ -22,7 +22,7 @@ pub struct PushState {
     #[stack(exec)]
     pub(crate) exec: Stack<PushInstruction>,
     #[stack]
-    pub(crate) int: Stack<PushInteger>,
+    pub(crate) int: Stack<i64>,
     #[stack]
     pub(crate) float: Stack<OrderedFloat<f64>>,
     #[stack]
@@ -103,7 +103,7 @@ mod simple_check {
         instruction::{
             BoolInstruction, FloatInstruction, IntInstruction, PushInstruction, VariableName,
         },
-        push_vm::push_state::{PushInteger, PushState},
+        push_vm::push_state::PushState,
     };
 
     use super::State;
@@ -114,7 +114,7 @@ mod simple_check {
             PushInstruction::push_bool(b)
         }
 
-        fn push_int(i: PushInteger) -> PushInstruction {
+        fn push_int(i: i64) -> PushInstruction {
             PushInstruction::push_int(i)
         }
 

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -332,9 +332,8 @@ impl<T> Stack<T> {
     /// ```
     /// # use push::push_vm::stack::StackError;
     /// # use push::push_vm::stack::Stack;
-    /// # use push::push_vm::PushInteger;
     /// #
-    /// let mut stack: Stack<PushInteger> = Stack::default();
+    /// let mut stack: Stack<i64> = Stack::default();
     /// assert_eq!(stack.size(), 0);
     ///
     /// stack.try_extend(vec![5, 8, 9])?;


### PR DESCRIPTION
Use i64 instead as discussed in #13  ( Closes #13 )