### PR TITLE
Use proper variable name in doctests

### DIFF
--- a/packages/push-macros/src/push_state/printing/generate_builder.rs
+++ b/packages/push-macros/src/push_state/printing/generate_builder.rs
@@ -223,6 +223,7 @@ pub fn generate_builder(
                         ),
                         Import::SuperRelativePath(import_utilities_path.clone()),
                     ];
+                    let var_name = derived_ident!(stack_ident, "_stack").unraw();
 
                     let outtro = "# Ok::<(), StackError>(())";
 
@@ -232,10 +233,10 @@ pub fn generate_builder(
                             .with_no_program()
                             .#fn_ident([#sample_values])?
                             .build();
-                        let int_stack: &Stack<<#ty as StackType>::Type> =
+                        let #var_name: &Stack<<#ty as StackType>::Type> =
                             state.stack::<<#ty as StackType>::Type>();
-                        assert_eq!(int_stack.size(), #number_values);
-                        assert_eq!(int_stack.top()?, &#first_value);
+                        assert_eq!(#var_name.size(), #number_values);
+                        assert_eq!(#var_name.top()?, &#first_value);
                     };
 
                     let ignore_attr = (


### PR DESCRIPTION
All doctests were using `int_stack` for the variable name before, now it uses the correct stack type depending on the stack the tests are generated for.