### PR TITLE
Improve creation of generators

### DIFF
--- a/packages/ec-core/src/generator/collection.rs
+++ b/packages/ec-core/src/generator/collection.rs
@@ -1,16 +1,18 @@
-/// This module contains the implementation of the `CollectionGenerator` struct and
-/// related traits and functions.
+/// This module contains the implementation of the `CollectionGenerator` struct
+/// and related traits and functions.
 ///
-/// The `CollectionGenerator` struct is used to generate a collection of random elements.
-/// It takes an element generator and a size as input, and generates a `Vec` of random elements
-/// based on the specified size and the mechanism for generating random elements.
+/// The `CollectionGenerator` struct is used to generate a collection of random
+/// elements. It takes an element generator and a size as input, and generates a
+/// `Vec` of random elements based on the specified size and the mechanism for
+/// generating random elements.
 ///
-/// The module also defines the `ConvertToCollectionGenerator` trait, which provides methods
-/// for converting a type into a `CollectionGenerator`. This trait is implemented for any
-/// type that implements the `Generator` trait.
+/// The module also defines the `ConvertToCollectionGenerator` trait, which
+/// provides methods for converting a type into a `CollectionGenerator`. This
+/// trait is implemented for any type that implements the `Generator` trait.
 ///
-/// Finally, the module implements the `Generator` trait for the `CollectionGenerator`
-/// struct, allowing it to generate a `Vec` of random elements using the `generate` method.
+/// Finally, the module implements the `Generator` trait for the
+/// `CollectionGenerator` struct, allowing it to generate a `Vec` of random
+/// elements using the `generate` method.
 use std::iter::repeat_with;
 
 use rand::rngs::ThreadRng;
@@ -28,7 +30,8 @@ pub struct CollectionGenerator<C> {
 }
 
 impl<C> CollectionGenerator<C> {
-    /// Create a new `CollectionGenerator` with the given element generator and size.
+    /// Create a new `CollectionGenerator` with the given element generator and
+    /// size.
     pub const fn new(element_generator: C, size: usize) -> Self {
         Self {
             element_generator,
@@ -48,10 +51,10 @@ pub trait ConvertToCollectionGenerator {
     where
         Self: Sized;
 
-    /// Convert a reference to the type into a `CollectionGenerator` that generates
-    /// collections of the specified size, using `self` to generate the individual elements.
-    /// This takes a reference to the type so the type can be used elsewhere when
-    /// necessary.
+    /// Convert a reference to the type into a `CollectionGenerator` that
+    /// generates collections of the specified size, using `self` to
+    /// generate the individual elements. This takes a reference to the type
+    /// so the type can be used elsewhere when necessary.
     fn to_collection_generator(&self, size: usize) -> CollectionGenerator<&Self>
     where
         Self: Sized;
@@ -64,8 +67,9 @@ impl<C> ConvertToCollectionGenerator for C {
         CollectionGenerator::new(self, size)
     }
 
-    /// Convert a reference to the type into a `CollectionGenerator` that generates
-    /// collections of the specified size, using `&self` to generate the individual elements.
+    /// Convert a reference to the type into a `CollectionGenerator` that
+    /// generates collections of the specified size, using `&self` to
+    /// generate the individual elements.
     fn to_collection_generator(&self, size: usize) -> CollectionGenerator<&Self>
     where
         Self: Sized,

--- a/packages/ec-core/src/generator/collection.rs
+++ b/packages/ec-core/src/generator/collection.rs
@@ -1,3 +1,16 @@
+/// This module contains the implementation of the `CollectionGenerator` struct and
+/// related traits and functions.
+///
+/// The `CollectionGenerator` struct is used to generate a collection of random elements.
+/// It takes an element generator and a size as input, and generates a `Vec` of random elements
+/// based on the specified size and the mechanism for generating random elements.
+///
+/// The module also defines the `ConvertToCollectionGenerator` trait, which provides methods
+/// for converting a type into a `CollectionGenerator`. This trait is implemented for any
+/// type that implements the `Generator` trait.
+///
+/// Finally, the module implements the `Generator` trait for the `CollectionGenerator`
+/// struct, allowing it to generate a `Vec` of random elements using the `generate` method.
 use std::iter::repeat_with;
 
 use rand::rngs::ThreadRng;
@@ -10,8 +23,55 @@ use super::Generator;
 /// `element_generator` is used to generate individual elements.
 #[allow(clippy::module_name_repetitions)]
 pub struct CollectionGenerator<C> {
-    pub size: usize,
     pub element_generator: C,
+    pub size: usize,
+}
+
+impl<C> CollectionGenerator<C> {
+    /// Create a new `CollectionGenerator` with the given element generator and size.
+    pub const fn new(element_generator: C, size: usize) -> Self {
+        Self {
+            element_generator,
+            size,
+        }
+    }
+}
+
+/// Trait to convert a type (typically some sort of gene generator) into a
+/// `CollectionGenerator` that generates collections of the specified size
+/// of random elements (genes).
+pub trait ConvertToCollectionGenerator {
+    /// Convert the type into a `CollectionGenerator` that generates collections
+    /// of the specified size, using `self` to generate the individual elements.
+    /// This takes ownership of the type.
+    fn into_collection_generator(self, size: usize) -> CollectionGenerator<Self>
+    where
+        Self: Sized;
+
+    /// Convert a reference to the type into a `CollectionGenerator` that generates
+    /// collections of the specified size, using `self` to generate the individual elements.
+    /// This takes a reference to the type so the type can be used elsewhere when
+    /// necessary.
+    fn to_collection_generator(&self, size: usize) -> CollectionGenerator<&Self>
+    where
+        Self: Sized;
+}
+
+impl<C> ConvertToCollectionGenerator for C {
+    /// Convert the type into a `CollectionGenerator` that generates collections
+    /// of the specified size, using `self` to generate the individual elements.
+    fn into_collection_generator(self, size: usize) -> CollectionGenerator<Self> {
+        CollectionGenerator::new(self, size)
+    }
+
+    /// Convert a reference to the type into a `CollectionGenerator` that generates
+    /// collections of the specified size, using `&self` to generate the individual elements.
+    fn to_collection_generator(&self, size: usize) -> CollectionGenerator<&Self>
+    where
+        Self: Sized,
+    {
+        CollectionGenerator::new(self, size)
+    }
 }
 
 /// Generate a `Vec` of random elements.

--- a/packages/ec-core/src/generator/mod.rs
+++ b/packages/ec-core/src/generator/mod.rs
@@ -15,6 +15,26 @@ pub trait Generator<T> {
     fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<T>;
 }
 
+/// Implement `Generator` for any reference to a `Generator`.
+impl<'a, T, U> Generator<T> for &'a U
+where
+    U: Generator<T>,
+{
+    fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<T> {
+        (**self).generate(rng)
+    }
+}
+
+/// Implement `Generator` for any mutable reference to a `Generator`.
+impl<'a, T, U> Generator<T> for &'a mut U
+where
+    U: Generator<T>,
+{
+    fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<T> {
+        (**self).generate(rng)
+    }
+}
+
 /// Generate a random element from an array of options.
 ///
 /// # Errors

--- a/packages/ec-core/src/individual/ec.rs
+++ b/packages/ec-core/src/individual/ec.rs
@@ -1,3 +1,6 @@
+/// This module contains the implementation of the `Ec` struct and related functionality.
+/// The `Ec` struct represents an individual in an evolutionary computation system.
+/// It provides methods for comparing individuals and displaying their contents.
 use std::{
     cmp::Ordering,
     fmt::{Debug, Display},
@@ -8,6 +11,8 @@ use rand::rngs::ThreadRng;
 use super::{scorer::Scorer, Individual};
 use crate::generator::Generator;
 
+/// `EcIndividual` is a struct that represents an individual in an evolutionary
+/// computation system. It contains a genome and the results of scoring the genome.
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct EcIndividual<G, R> {
@@ -19,16 +24,19 @@ impl<G, R> Individual for EcIndividual<G, R> {
     type Genome = G;
     type TestResults = R;
 
+    /// Get the genome of the individual.
     fn genome(&self) -> &Self::Genome {
         &self.genome
     }
 
+    /// Get the test results of the individual.
     fn test_results(&self) -> &Self::TestResults {
         &self.test_results
     }
 }
 
 impl<G, R> EcIndividual<G, R> {
+    /// Create a new `EcIndividual` with the given genome and test results.
     pub const fn new(genome: G, test_results: R) -> Self {
         Self {
             genome,
@@ -38,12 +46,14 @@ impl<G, R> EcIndividual<G, R> {
 }
 
 impl<G: Eq, R: Ord> Ord for EcIndividual<G, R> {
+    /// Compare two individuals based on their test results.
     fn cmp(&self, other: &Self) -> Ordering {
         self.test_results.cmp(&other.test_results)
     }
 }
 
 impl<G: PartialEq, R: PartialOrd> PartialOrd for EcIndividual<G, R> {
+    /// Compare two individuals based on their test results.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.test_results.partial_cmp(&other.test_results)
     }
@@ -52,14 +62,47 @@ impl<G: PartialEq, R: PartialOrd> PartialOrd for EcIndividual<G, R> {
 // TODO: Maybe change R to implement `Display` and have `TestResults` have a
 //   nice-ish display function.
 impl<G: Display, R: Debug> Display for EcIndividual<G, R> {
+    /// Display the genome and test results of the individual.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[{}]\n{:?}", self.genome(), self.test_results())
     }
 }
 
+/// A generator for creating individuals, which requires a genome generator and a
+/// scorer.
+///
+/// The genome generator is used to create the genome of the individual, and the
+/// scorer is used to score the genome.
 pub struct IndividualGenerator<GG, S> {
-    pub scorer: S,
     pub genome_generator: GG,
+    pub scorer: S,
+}
+
+impl<GG, S> IndividualGenerator<GG, S> {
+    /// Create a new `IndividualGenerator` with the given genome generator and
+    /// scorer.
+    pub const fn new(genome_generator: GG, scorer: S) -> Self {
+        Self {
+            genome_generator,
+            scorer,
+        }
+    }
+}
+
+/// A trait for adding a scorer to a genome generator, creating
+/// an `IndividualGenerator`.
+pub trait WithScorer<Scorer> {
+    /// Add a scorer to the genome generator, creating an `IndividualGenerator`.
+    fn with_scorer(self, scorer: Scorer) -> IndividualGenerator<Self, Scorer>
+    where
+        Self: Sized;
+}
+
+impl<GG, S> WithScorer<S> for GG {
+    /// Add a scorer to the genome generator, creating an `IndividualGenerator`.
+    fn with_scorer(self, scorer: S) -> IndividualGenerator<GG, S> {
+        IndividualGenerator::new(self, scorer)
+    }
 }
 
 // G is Genome
@@ -71,6 +114,12 @@ where
     GG: Generator<G>,
     S: Scorer<G, R>,
 {
+    /// Generate a new, random, individual.
+    ///
+    /// This creates a new genome of type `G` using the genome generator of
+    /// type `GG`, and then scores the genome using the scorer of type `S`.
+    /// The genome and the test results (of type `R`) are then
+    /// used to create a new `EcIndividual`.
     fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<EcIndividual<G, R>> {
         let genome = self.genome_generator.generate(rng)?;
         let test_results = self.scorer.score(&genome);

--- a/packages/ec-core/src/individual/ec.rs
+++ b/packages/ec-core/src/individual/ec.rs
@@ -1,6 +1,7 @@
-/// This module contains the implementation of the `Ec` struct and related functionality.
-/// The `Ec` struct represents an individual in an evolutionary computation system.
-/// It provides methods for comparing individuals and displaying their contents.
+/// This module contains the implementation of the `Ec` struct and related
+/// functionality. The `Ec` struct represents an individual in an evolutionary
+/// computation system. It provides methods for comparing individuals and
+/// displaying their contents.
 use std::{
     cmp::Ordering,
     fmt::{Debug, Display},
@@ -12,7 +13,8 @@ use super::{scorer::Scorer, Individual};
 use crate::generator::Generator;
 
 /// `EcIndividual` is a struct that represents an individual in an evolutionary
-/// computation system. It contains a genome and the results of scoring the genome.
+/// computation system. It contains a genome and the results of scoring the
+/// genome.
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct EcIndividual<G, R> {
@@ -68,8 +70,8 @@ impl<G: Display, R: Debug> Display for EcIndividual<G, R> {
     }
 }
 
-/// A generator for creating individuals, which requires a genome generator and a
-/// scorer.
+/// A generator for creating individuals, which requires a genome generator and
+/// a scorer.
 ///
 /// The genome generator is used to create the genome of the individual, and the
 /// scorer is used to score the genome.

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -28,7 +28,10 @@ pub struct Bitstring {
     pub bits: Vec<bool>,
 }
 
-impl Generator<Bitstring> for CollectionGenerator<BoolGenerator> {
+impl<BG> Generator<Bitstring> for CollectionGenerator<BG>
+where
+    BG: Generator<bool>,
+{
     fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<Bitstring> {
         let bits = self.generate(rng)?;
         Ok(Bitstring { bits })

--- a/packages/push/src/genome/plushy.rs
+++ b/packages/push/src/genome/plushy.rs
@@ -101,7 +101,10 @@ impl Linear for Plushy {
     }
 }
 
-impl Generator<Plushy> for CollectionGenerator<GeneGenerator> {
+impl<GG> Generator<Plushy> for CollectionGenerator<GG>
+where
+    GG: Generator<PushGene>,
+{
     fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<Plushy> {
         Ok(Plushy {
             genes: self.generate(rng)?,


### PR DESCRIPTION
The primary goal of this PR is to improve the mechanisms for constructing generators, so we can chain them as is now done in `packages/push/examples/complex_regression/main.rs`.

We added constructors (`::new()`) and factory methods for both `CollectionGenerator` and `IndividualGenerator`. The factory methods allow us to chain generator construction in a nice way, avoiding the need for a bunch of intermediate variables.

We also created implementations of `Generator` for references (mutable and immutable) to `Generator`, which allows us to pass references to generators around and they can be used as "actual" generators.

In the process we found (and fixed, largely thanks to esitsu@Twitch!) a "bug" in `Bitstring` and `Plushy` where their implementations of `CollectionGenerator` were overly constrained. This was blocking `complex_regression/main.rs` from compiling and I was frankly baffled. Happily esitsu figured it out and got things moving again.

Special thanks to @JustusFluegel for the original idea and a lot of the design, and to esitsu@Twitch for lots of design help and huge help with the aforementioned "bug".