### PR TITLE
Configure vscode to use our rustfmt config

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,2 @@
+[language-server.rust-analyzer.config.rustfmt]
+overrideCommand = ["rustfmt-unstable", "--", "rustfmt"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,10 @@
         "underflows",
         "Wrappable"
     ],
-    "todo-tree.tree.showCountsInTree": true
+    "todo-tree.tree.showCountsInTree": true,
+    "rust-analyzer.rustfmt.overrideCommand": [
+        "rustfmt-unstable",
+        "--",
+        "rustfmt"
+    ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# IDE setup
+We are currently using unstable rustfmt features in our rustfmt.toml, which isn't supported through rustfmt stable natively, as rustfmt v1 stable only supports unstable options via the command line. As such we are currently using a small wrapper around rustfmt, called `rustfmt-unstable`, which essentially passes the arguments in the config file via the cli.
+
+To be consistent in ci & in our local development experience, we also overwrote the rustfmt command for rust-analyzer in both vscode and helix.
+If you are using one of these editors you will need to install rustfmt-unstable via `cargo install rustfmt-unstable` to get formatting working.


### PR DESCRIPTION
@NicMcPhee make sure your rustfmt-unstable version is recent enough, I only added automatic config detection in the workspace recently, I don't know if it was already present when we tested it. (`cargo install rustfmt-unstable`)