### PR TITLE
Generalize scorer & training/testing cases

### DIFF
--- a/packages/ec-core/src/individual/ec.rs
+++ b/packages/ec-core/src/individual/ec.rs
@@ -9,7 +9,10 @@ use std::{
 
 use rand::rngs::ThreadRng;
 
-use super::{scorer::Scorer, Individual};
+use super::{
+    scorer::{FnScorer, Scorer},
+    Individual,
+};
 use crate::generator::Generator;
 
 /// `EcIndividual` is a struct that represents an individual in an evolutionary
@@ -93,16 +96,28 @@ impl<GG, S> IndividualGenerator<GG, S> {
 
 /// A trait for adding a scorer to a genome generator, creating
 /// an `IndividualGenerator`.
-pub trait WithScorer<Scorer> {
+pub trait WithScorer {
     /// Add a scorer to the genome generator, creating an `IndividualGenerator`.
-    fn with_scorer(self, scorer: Scorer) -> IndividualGenerator<Self, Scorer>
+    fn with_scorer<S, G, R>(self, scorer: S) -> IndividualGenerator<Self, S>
     where
-        Self: Sized;
+        Self: Sized,
+        S: Scorer<G, R>;
+
+    fn with_scorer_fn<F, G, R>(self, f: F) -> IndividualGenerator<Self, FnScorer<F>>
+    where
+        Self: Sized,
+        F: Fn(&G) -> R,
+    {
+        self.with_scorer(FnScorer(f))
+    }
 }
 
-impl<GG, S> WithScorer<S> for GG {
+impl<GG> WithScorer for GG {
     /// Add a scorer to the genome generator, creating an `IndividualGenerator`.
-    fn with_scorer(self, scorer: S) -> IndividualGenerator<GG, S> {
+    fn with_scorer<S, G, R>(self, scorer: S) -> IndividualGenerator<GG, S>
+    where
+        S: Scorer<G, R>,
+    {
         IndividualGenerator::new(self, scorer)
     }
 }

--- a/packages/ec-core/src/individual/ec.rs
+++ b/packages/ec-core/src/individual/ec.rs
@@ -98,10 +98,10 @@ impl<GG, S> IndividualGenerator<GG, S> {
 /// an `IndividualGenerator`.
 pub trait WithScorer {
     /// Add a scorer to the genome generator, creating an `IndividualGenerator`.
-    fn with_scorer<S, G, R>(self, scorer: S) -> IndividualGenerator<Self, S>
+    fn with_scorer<S, G>(self, scorer: S) -> IndividualGenerator<Self, S>
     where
         Self: Sized,
-        S: Scorer<G, R>;
+        S: Scorer<G>;
 
     fn with_scorer_fn<F, G, R>(self, f: F) -> IndividualGenerator<Self, FnScorer<F>>
     where
@@ -114,9 +114,9 @@ pub trait WithScorer {
 
 impl<GG> WithScorer for GG {
     /// Add a scorer to the genome generator, creating an `IndividualGenerator`.
-    fn with_scorer<S, G, R>(self, scorer: S) -> IndividualGenerator<GG, S>
+    fn with_scorer<S, G>(self, scorer: S) -> IndividualGenerator<GG, S>
     where
-        S: Scorer<G, R>,
+        S: Scorer<G>,
     {
         IndividualGenerator::new(self, scorer)
     }
@@ -125,19 +125,18 @@ impl<GG> WithScorer for GG {
 // G is Genome
 // GG is Genome generator
 // S is Scorer
-// R is the TestResult type
-impl<G, GG, S, R> Generator<EcIndividual<G, R>> for IndividualGenerator<GG, S>
+impl<G, GG, S> Generator<EcIndividual<G, S::Score>> for IndividualGenerator<GG, S>
 where
     GG: Generator<G>,
-    S: Scorer<G, R>,
+    S: Scorer<G>,
 {
     /// Generate a new, random, individual.
     ///
     /// This creates a new genome of type `G` using the genome generator of
     /// type `GG`, and then scores the genome using the scorer of type `S`.
-    /// The genome and the test results (of type `R`) are then
+    /// The genome and the test results (of type `S::Score`) are then
     /// used to create a new `EcIndividual`.
-    fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<EcIndividual<G, R>> {
+    fn generate(&self, rng: &mut ThreadRng) -> anyhow::Result<EcIndividual<G, S::Score>> {
         let genome = self.genome_generator.generate(rng)?;
         let test_results = self.scorer.score(&genome);
         Ok(EcIndividual::new(genome, test_results))

--- a/packages/ec-core/src/individual/scorer.rs
+++ b/packages/ec-core/src/individual/scorer.rs
@@ -19,6 +19,6 @@ where
     T: Scorer<G, R>,
 {
     fn score(&self, genome: &G) -> R {
-        (*self).score(genome)
+        (**self).score(genome)
     }
 }

--- a/packages/ec-core/src/individual/scorer.rs
+++ b/packages/ec-core/src/individual/scorer.rs
@@ -1,24 +1,31 @@
-pub trait Scorer<G, R> {
+pub trait Scorer<G> {
+    type Score;
+
     /// Take a reference to a genome and return some score type `R`.
-    fn score(&self, genome: &G) -> R;
+    fn score(&self, genome: &G) -> Self::Score;
 }
 
+#[derive(Clone, Copy)]
 pub struct FnScorer<T>(pub T);
 
-impl<G, R, T> Scorer<G, R> for FnScorer<T>
+impl<G, R, T> Scorer<G> for FnScorer<T>
 where
     T: Fn(&G) -> R,
 {
-    fn score(&self, genome: &G) -> R {
+    type Score = R;
+
+    fn score(&self, genome: &G) -> Self::Score {
         self.0(genome)
     }
 }
 
-impl<G, R, T> Scorer<G, R> for &T
+impl<G, T> Scorer<G> for &T
 where
-    T: Scorer<G, R>,
+    T: Scorer<G>,
 {
-    fn score(&self, genome: &G) -> R {
+    type Score = T::Score;
+
+    fn score(&self, genome: &G) -> Self::Score {
         (**self).score(genome)
     }
 }

--- a/packages/ec-core/src/individual/scorer.rs
+++ b/packages/ec-core/src/individual/scorer.rs
@@ -3,11 +3,22 @@ pub trait Scorer<G, R> {
     fn score(&self, genome: &G) -> R;
 }
 
-impl<G, R, T> Scorer<G, R> for T
+pub struct FnScorer<T>(pub T);
+
+impl<G, R, T> Scorer<G, R> for FnScorer<T>
 where
     T: Fn(&G) -> R,
 {
     fn score(&self, genome: &G) -> R {
-        self(genome)
+        self.0(genome)
+    }
+}
+
+impl<G, R, T> Scorer<G, R> for &T
+where
+    T: Scorer<G, R>,
+{
+    fn score(&self, genome: &G) -> R {
+        (*self).score(genome)
     }
 }

--- a/packages/ec-core/src/operator/genome_scorer.rs
+++ b/packages/ec-core/src/operator/genome_scorer.rs
@@ -3,6 +3,10 @@ use anyhow::Result;
 use super::{composable::Wrappable, Composable, Operator};
 use crate::{individual::ec::EcIndividual, population::Population, test_results::TestResults};
 
+// TODO: We need to update `GenomeScorer` to take advantage of the new changes
+//   to the `Scorer` trait. We use `Fn` in the `impl Operator` and that should
+//   be updated to use `Scorer` instead.
+
 pub struct GenomeScorer<GM, S> {
     genome_maker: GM,
     scorer: S,

--- a/packages/ec-core/src/operator/genome_scorer.rs
+++ b/packages/ec-core/src/operator/genome_scorer.rs
@@ -6,10 +6,6 @@ use crate::{
     population::Population,
 };
 
-// TODO: We need to update `GenomeScorer` to take advantage of the new changes
-//   to the `Scorer` trait. We use `Fn` in the `impl Operator` and that should
-//   be updated to use `Scorer` instead.
-
 pub struct GenomeScorer<GM, S> {
     genome_maker: GM,
     scorer: S,

--- a/packages/ec-core/src/operator/genome_scorer.rs
+++ b/packages/ec-core/src/operator/genome_scorer.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 
 use super::{composable::Wrappable, Composable, Operator};
-use crate::{individual::ec::EcIndividual, population::Population, test_results::TestResults};
+use crate::{
+    individual::{ec::EcIndividual, scorer::Scorer},
+    population::Population,
+};
 
 // TODO: We need to update `GenomeScorer` to take advantage of the new changes
 //   to the `Scorer` trait. We use `Fn` in the `impl Operator` and that should
@@ -34,13 +37,13 @@ impl<'pop, GM, S, R, P> Operator<&'pop P> for GenomeScorer<GM, S>
 where
     P: Population,
     GM: Operator<&'pop P>,
-    S: Fn(&GM::Output) -> TestResults<R>,
+    S: Scorer<GM::Output, Score = R>,
 {
-    type Output = EcIndividual<GM::Output, TestResults<R>>;
+    type Output = EcIndividual<GM::Output, S::Score>;
 
     fn apply(&self, population: &'pop P, rng: &mut rand::rngs::ThreadRng) -> Result<Self::Output> {
         let genome = self.genome_maker.apply(population, rng)?;
-        let score = (self.scorer)(&genome);
+        let score = self.scorer.score(&genome);
         // TODO: We probably don't want to bake in `EcIndividual` here, but instead
         //   have things be more general than that.
         Ok(EcIndividual::new(genome, score))

--- a/packages/ec-ga-cli/src/main.rs
+++ b/packages/ec-ga-cli/src/main.rs
@@ -7,7 +7,10 @@ use clap::Parser;
 use ec_core::{
     generation::Generation,
     generator::{collection::CollectionGenerator, Generator},
-    individual::ec::{self, EcIndividual},
+    individual::{
+        ec::{self, EcIndividual},
+        scorer::FnScorer,
+    },
     operator::{
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
@@ -69,7 +72,7 @@ fn main() -> Result<()> {
     };
 
     let individual_generator = ec::IndividualGenerator {
-        scorer,
+        scorer: FnScorer(scorer),
         genome_generator: bitstring_generator,
     };
 

--- a/packages/ec-push-cli/src/main.rs
+++ b/packages/ec-push-cli/src/main.rs
@@ -7,7 +7,10 @@ use clap::Parser;
 use ec_core::{
     generation::Generation,
     generator::{collection::CollectionGenerator, Generator},
-    individual::ec::{self, EcIndividual},
+    individual::{
+        ec::{self, EcIndividual},
+        scorer::FnScorer,
+    },
     operator::{
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
@@ -121,7 +124,7 @@ fn main() -> Result<()> {
 
     let individual_generator = ec::IndividualGenerator {
         genome_generator: plushy_generator,
-        scorer,
+        scorer: FnScorer(scorer),
     };
 
     let population_generator = CollectionGenerator {

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -20,7 +20,7 @@ use ec_core::{
 use ec_linear::mutator::umad::Umad;
 use ordered_float::OrderedFloat;
 use push::{
-    evaluation::cases::Cases,
+    evaluation::cases::{Case, Cases},
     genome::plushy::{GeneGenerator, Plushy},
     instruction::{variable_name::VariableName, FloatInstruction},
     push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
@@ -66,8 +66,7 @@ fn build_push_state(
 
 fn score_program(
     program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator,
-    input: Of64,
-    expected_output: Of64,
+    Case { input, output }: Case<Of64>,
 ) -> Of64 {
     let state = build_push_state(program, input);
     #[allow(clippy::option_if_let_else)]
@@ -76,7 +75,7 @@ fn score_program(
             final_state
                 .stack::<Of64>()
                 .top()
-                .map_or(PENALTY_VALUE, |answer| (answer - expected_output).abs()),
+                .map_or(PENALTY_VALUE, |answer| (answer - output).abs()),
         ),
         Err(_) => {
             // Do some logging, perhaps?
@@ -92,7 +91,7 @@ fn score_genome(
     let program = Vec::<PushProgram>::from(genome.clone());
     let errors: TestResults<test_results::Error<Of64>> = training_cases
         .iter()
-        .map(|case| score_program(program.iter().cloned(), case.input, case.output))
+        .map(|&case| score_program(program.iter().cloned(), case))
         .collect();
     errors
 }

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -36,6 +36,10 @@ use crate::args::{Args, RunModel};
  * https://github.com/lspector/propeller/blob/71d378f49fdf88c14dda88387291c9c7be0f1277/src/propeller/problems/complex_regression.cljc
  */
 
+// The penalty value to use when an evolved program doesn't have an expected
+// "return" value on the appropriate stack at the end of its execution.
+const PENALTY_VALUE: f64 = 1_000.0;
+
 type Of64 = OrderedFloat<f64>;
 
 /// The target polynomial is (x^3 + 1)^3 + 1
@@ -65,10 +69,6 @@ fn score_program(
     input: Of64,
     expected_output: Of64,
 ) -> Of64 {
-    // The penalty value to use when an evolved program doesn't have an expected
-    // "return" value on the appropriate stack at the end of its execution.
-    const PENALTY_VALUE: f64 = 1_000.0;
-
     let state = build_push_state(program, input);
     #[allow(clippy::option_if_let_else)]
     match state.run_to_completion() {

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -101,15 +101,13 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     // Inputs from -4 (inclusive) to 4 (exclusive) in increments of 0.25.
-    let training_inputs = (-4 * 4..4 * 4).map(|n| OrderedFloat(f64::from(n) / 4.0));
+    let training_inputs = (-4 * 4..4 * 4).map(|n| Of64::from(n) / 4.0);
     let training_cases = Cases::from_inputs(training_inputs, |&i| target_fn(i));
 
     // The range want is -4 1/8, -3 7/8, -3 5/8, ..., 3 7/8, 4 1/8.
     // I have to multiply that by 8 to get integer values, so:
     // -33, -31, -29, ..., 31, 33.
-    let testing_inputs = (-33..=33)
-        .step_by(2)
-        .map(|n| OrderedFloat(f64::from(n) / 8.0));
+    let testing_inputs = (-33..=33).step_by(2).map(|n| Of64::from(n) / 8.0);
     let _testing_cases = Cases::from_inputs(testing_inputs, |&i| target_fn(i));
 
     /*

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -43,6 +43,7 @@ const PENALTY_VALUE: f64 = 1_000.0;
 type Of64 = OrderedFloat<f64>;
 
 /// The target polynomial is (x^3 + 1)^3 + 1
+/// i.e., x^9 + 3x^6 + 3x^3 + 2
 fn target_fn(input: Of64) -> Of64 {
     let sub_expr = input * input * input + 1.0;
     sub_expr * sub_expr * sub_expr + 1.0

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use ec_core::{
     generation::Generation,
     generator::{collection::ConvertToCollectionGenerator, Generator},
-    individual::ec::WithScorer,
+    individual::{ec::WithScorer, scorer::FnScorer},
     operator::{
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
@@ -117,9 +117,11 @@ fn main() -> Result<()> {
      * i.e., the absolute difference between the returned value and the
      * expected value.
      */
-    let scorer = |genome: &Plushy| -> TestResults<test_results::Error<Of64>> {
-        score_genome(genome, &training_cases)
-    };
+    let scorer = FnScorer(
+        |genome: &Plushy| -> TestResults<test_results::Error<Of64>> {
+            score_genome(genome, &training_cases)
+        },
+    );
 
     let selector = Lexicase::new(training_cases.len());
 
@@ -140,7 +142,7 @@ fn main() -> Result<()> {
 
     let population = gene_generator
         .to_collection_generator(args.max_initial_instructions)
-        .with_scorer_fn(&scorer)
+        .with_scorer(scorer)
         .into_collection_generator(args.population_size)
         .generate(&mut rng)?;
 

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -35,17 +35,62 @@ use crate::args::{Args, RunModel};
  * https://github.com/lspector/propeller/blob/71d378f49fdf88c14dda88387291c9c7be0f1277/src/propeller/problems/complex_regression.cljc
  */
 
-fn main() -> Result<()> {
+ /// The target polynomial is (x^3 + 1)^3 + 1
+ fn target_fn(input: OrderedFloat<f64>) -> OrderedFloat<f64> {
+    let sub_expr = input * input * input + 1.0;
+    sub_expr * sub_expr * sub_expr + 1.0
+}
+
+fn build_push_state(program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator, input: OrderedFloat<f64>) -> PushState {
+    #[allow(clippy::unwrap_used)]
+    PushState::builder()
+        .with_max_stack_size(1000)
+        .with_program(program)
+        // This will return an error if the program is longer than the allowed
+        // max stack size.
+        // We arguably should check that and return an error here.
+        .unwrap()
+        .with_float_input("x", input)
+        .build()
+}
+
+fn score_program(program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator, input: OrderedFloat<f64>, expected_output: OrderedFloat<f64>) -> OrderedFloat<f64> {
     // The penalty value to use when an evolved program doesn't have an expected
     // "return" value on the appropriate stack at the end of its execution.
     const PENALTY_VALUE: f64 = 1_000.0;
 
+    let state = build_push_state(program, input);
+    #[allow(clippy::option_if_let_else)]
+    match state.run_to_completion() {
+        Ok(final_state) => OrderedFloat(
+            final_state
+                .stack::<OrderedFloat<f64>>()
+                .top()
+                .map_or(PENALTY_VALUE, |answer| (answer - expected_output).abs()),
+        ),
+        Err(_) => {
+            // Do some logging, perhaps?
+            OrderedFloat(PENALTY_VALUE)
+        }
+    }
+}
+
+fn main() -> Result<()> {
     let args = Args::parse();
 
     // Inputs from -4 (inclusive) to 4 (exclusive) in increments of 0.25.
-    let training_cases = (-4 * 4..4 * 4)
-        .map(|n| OrderedFloat(f64::from(n) / 4.0))
-        .collect::<Vec<_>>();
+    let training_inputs = (-4 * 4..4 * 4)
+        .map(|n| OrderedFloat(f64::from(n) / 4.0));
+    let training_cases = training_inputs
+        .map(|input| (input, target_fn(input))).collect::<Vec<_>>();
+
+    // The range want is -4 1/8, -3 7/8, -3 5/8, ..., 3 7/8, 4 1/8.
+    // I have to multiply that by 8 to get integer values, so:
+    // -33, -31, -29, ..., 31, 33.
+    let testing_inputs = (-33..=33).step_by(2)
+        .map(|n| OrderedFloat(f64::from(n) / 8.0));
+    let _testing_cases = testing_inputs
+        .map(|input| (input, target_fn(input))).collect::<Vec<_>>();
 
     /*
      * The `scorer` will need to take an evolved program (sequence of
@@ -53,39 +98,13 @@ fn main() -> Result<()> {
      * (exclusive) in increments of 0.25, collecting together the errors,
      * i.e., the absolute difference between the returned value and the
      * expected value.
-     *
-     * The target polynomial is (x^3 + 1)^3 + 1
      */
     let scorer = |genome: &Plushy| -> TestResults<test_results::Error<OrderedFloat<f64>>> {
         let program = Vec::<PushProgram>::from(genome.clone());
         let errors: TestResults<test_results::Error<OrderedFloat<f64>>> = training_cases
             .iter()
-            .map(|input| {
-                #[allow(clippy::unwrap_used)]
-                let state = PushState::builder()
-                    .with_max_stack_size(1000)
-                    .with_program(program.clone())
-                    // This will return an error if the program is longer than the allowed
-                    // max stack size.
-                    // We arguably should check that and return an error here.
-                    .unwrap()
-                    .with_float_input("x", *input)
-                    .build();
-                let sub_expr = *input * *input * *input + 1.0;
-                let expected = sub_expr * sub_expr * sub_expr + 1.0;
-                #[allow(clippy::option_if_let_else)]
-                match state.run_to_completion() {
-                    Ok(final_state) => OrderedFloat(
-                        final_state
-                            .stack::<OrderedFloat<f64>>()
-                            .top()
-                            .map_or(PENALTY_VALUE, |answer| (answer - expected).abs()),
-                    ),
-                    Err(_) => {
-                        // Do some logging, perhaps?
-                        OrderedFloat(PENALTY_VALUE)
-                    }
-                }
+            .map(|&(input, expected_output)| {
+                score_program(program.iter().cloned(), input, expected_output)
             })
             .collect();
         errors

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use ec_core::{
     generation::Generation,
     generator::{collection::ConvertToCollectionGenerator, Generator},
-    individual::{ec::WithScorer, scorer::FnScorer},
+    individual::ec::WithScorer,
     operator::{
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -35,13 +35,16 @@ use crate::args::{Args, RunModel};
  * https://github.com/lspector/propeller/blob/71d378f49fdf88c14dda88387291c9c7be0f1277/src/propeller/problems/complex_regression.cljc
  */
 
- /// The target polynomial is (x^3 + 1)^3 + 1
- fn target_fn(input: OrderedFloat<f64>) -> OrderedFloat<f64> {
+/// The target polynomial is (x^3 + 1)^3 + 1
+fn target_fn(input: OrderedFloat<f64>) -> OrderedFloat<f64> {
     let sub_expr = input * input * input + 1.0;
     sub_expr * sub_expr * sub_expr + 1.0
 }
 
-fn build_push_state(program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator, input: OrderedFloat<f64>) -> PushState {
+fn build_push_state(
+    program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator,
+    input: OrderedFloat<f64>,
+) -> PushState {
     #[allow(clippy::unwrap_used)]
     PushState::builder()
         .with_max_stack_size(1000)
@@ -54,7 +57,11 @@ fn build_push_state(program: impl DoubleEndedIterator<Item = PushProgram> + Exac
         .build()
 }
 
-fn score_program(program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator, input: OrderedFloat<f64>, expected_output: OrderedFloat<f64>) -> OrderedFloat<f64> {
+fn score_program(
+    program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator,
+    input: OrderedFloat<f64>,
+    expected_output: OrderedFloat<f64>,
+) -> OrderedFloat<f64> {
     // The penalty value to use when an evolved program doesn't have an expected
     // "return" value on the appropriate stack at the end of its execution.
     const PENALTY_VALUE: f64 = 1_000.0;
@@ -79,18 +86,20 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     // Inputs from -4 (inclusive) to 4 (exclusive) in increments of 0.25.
-    let training_inputs = (-4 * 4..4 * 4)
-        .map(|n| OrderedFloat(f64::from(n) / 4.0));
+    let training_inputs = (-4 * 4..4 * 4).map(|n| OrderedFloat(f64::from(n) / 4.0));
     let training_cases = training_inputs
-        .map(|input| (input, target_fn(input))).collect::<Vec<_>>();
+        .map(|input| (input, target_fn(input)))
+        .collect::<Vec<_>>();
 
     // The range want is -4 1/8, -3 7/8, -3 5/8, ..., 3 7/8, 4 1/8.
     // I have to multiply that by 8 to get integer values, so:
     // -33, -31, -29, ..., 31, 33.
-    let testing_inputs = (-33..=33).step_by(2)
+    let testing_inputs = (-33..=33)
+        .step_by(2)
         .map(|n| OrderedFloat(f64::from(n) / 8.0));
     let _testing_cases = testing_inputs
-        .map(|input| (input, target_fn(input))).collect::<Vec<_>>();
+        .map(|input| (input, target_fn(input)))
+        .collect::<Vec<_>>();
 
     /*
      * The `scorer` will need to take an evolved program (sequence of

--- a/packages/push/src/evaluation/cases.rs
+++ b/packages/push/src/evaluation/cases.rs
@@ -1,0 +1,99 @@
+#[derive(Debug)]
+pub struct Case<Input, Output = Input> {
+    pub input: Input,
+    pub output: Output,
+}
+
+#[derive(Debug)]
+pub struct Cases<Input, Output = Input> {
+    cases: Vec<Case<Input, Output>>,
+}
+
+impl<Input, Output> Cases<Input, Output> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { cases: Vec::new() }
+    }
+
+    pub fn from_inputs(
+        inputs: impl Iterator<Item = Input>,
+        target_function: impl Fn(&Input) -> Output,
+    ) -> Self {
+        inputs
+            .map(|input| Case {
+                output: target_function(&input),
+                input,
+            })
+            .collect()
+    }
+
+    // TODO: Add `from` that selects randomly from some cases
+    // TODO: Add `from` that gets cases from an external source
+    //    Maybe outside of this type?
+
+    pub fn add_case(&mut self, input: Input, output: Output) {
+        self.cases.push(Case { input, output });
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<Case<Input, Output>> {
+        self.cases.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<Case<Input, Output>> {
+        self.cases.iter_mut()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.cases.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.cases.len()
+    }
+}
+
+impl<Input, Output> Default for Cases<Input, Output> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Input, Output, C> FromIterator<C> for Cases<Input, Output>
+where
+    C: Into<Case<Input, Output>>,
+{
+    fn from_iter<T: IntoIterator<Item = C>>(iter: T) -> Self {
+        Self {
+            cases: iter.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl<Input, Output> IntoIterator for Cases<Input, Output> {
+    type Item = Case<Input, Output>;
+    type IntoIter = std::vec::IntoIter<Case<Input, Output>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.cases.into_iter()
+    }
+}
+
+impl<'a, Input, Output> IntoIterator for &'a Cases<Input, Output> {
+    type Item = &'a Case<Input, Output>;
+    type IntoIter = std::slice::Iter<'a, Case<Input, Output>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.cases.iter()
+    }
+}
+
+impl<'a, Input, Output> IntoIterator for &'a mut Cases<Input, Output> {
+    type Item = &'a mut Case<Input, Output>;
+    type IntoIter = std::slice::IterMut<'a, Case<Input, Output>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.cases.iter_mut()
+    }
+}

--- a/packages/push/src/evaluation/cases.rs
+++ b/packages/push/src/evaluation/cases.rs
@@ -1,7 +1,25 @@
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct Case<Input, Output = Input> {
     pub input: Input,
     pub output: Output,
+}
+
+impl<Input, Output> From<(Input, Output)> for Case<Input, Output> {
+    fn from((input, output): (Input, Output)) -> Self {
+        Self { input, output }
+    }
+}
+
+impl<Input, Output> From<Case<Input, Output>> for (Input, Output) {
+    fn from(case: Case<Input, Output>) -> (Input, Output) {
+        (case.input, case.output)
+    }
+}
+
+impl<Input, Output> Case<Input, Output> {
+    pub const fn new(input: Input, output: Output) -> Self {
+        Self { input, output }
+    }
 }
 
 #[derive(Debug)]
@@ -20,9 +38,9 @@ impl<Input, Output> Cases<Input, Output> {
         target_function: impl Fn(&Input) -> Output,
     ) -> Self {
         inputs
-            .map(|input| Case {
-                output: target_function(&input),
-                input,
+            .map(|input| {
+                let output = target_function(&input);
+                Case::new(input, output)
             })
             .collect()
     }
@@ -31,8 +49,14 @@ impl<Input, Output> Cases<Input, Output> {
     // TODO: Add `from` that gets cases from an external source
     //    Maybe outside of this type?
 
-    pub fn add_case(&mut self, input: Input, output: Output) {
-        self.cases.push(Case { input, output });
+    pub fn add_case(&mut self, case: impl Into<Case<Input, Output>>) {
+        self.cases.push(case.into());
+    }
+
+    #[must_use]
+    pub fn with_case(mut self, case: impl Into<Case<Input, Output>>) -> Self {
+        self.add_case(case);
+        self
     }
 
     pub fn iter(&self) -> std::slice::Iter<Case<Input, Output>> {

--- a/packages/push/src/evaluation/cases.rs
+++ b/packages/push/src/evaluation/cases.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Case<Input, Output = Input> {
     pub input: Input,
     pub output: Output,
@@ -75,6 +75,24 @@ impl<Input, Output> Cases<Input, Output> {
     #[must_use]
     pub fn len(&self) -> usize {
         self.cases.len()
+    }
+}
+
+pub trait WithTarget<Input> {
+    fn with_target<Output, F>(self, target_fn: F) -> Cases<Input, Output>
+    where
+        F: Fn(&Input) -> Output;
+}
+
+impl<T, Input> WithTarget<Input> for T
+where
+    T: IntoIterator<Item = Input>,
+{
+    fn with_target<Output, F>(self, target_fn: F) -> Cases<Input, Output>
+    where
+        F: Fn(&Input) -> Output,
+    {
+        Cases::from_inputs(self.into_iter(), target_fn)
     }
 }
 

--- a/packages/push/src/evaluation/mod.rs
+++ b/packages/push/src/evaluation/mod.rs
@@ -1,0 +1,1 @@
+pub mod cases;

--- a/packages/push/src/lib.rs
+++ b/packages/push/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod evaluation;
 pub mod genome;
 pub mod instruction;
 pub mod list_into;

--- a/packages/push/tests/cases.rs
+++ b/packages/push/tests/cases.rs
@@ -1,0 +1,69 @@
+use std::ops::Not;
+
+use push::{
+    evaluation::cases::{Case, Cases, WithTarget},
+    vec_into,
+};
+
+#[test]
+fn test_from_inputs() {
+    let cases = Cases::from_inputs(0..10, |x| x * 2);
+    assert_eq!(
+        cases.into_iter().collect::<Vec<_>>(),
+        (0..10).map(|x| Case::new(x, x * 2)).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_from_inputs_different_types() {
+    let cases = Cases::from_inputs(0..10, ToString::to_string);
+    assert_eq!(
+        cases.into_iter().collect::<Vec<_>>(),
+        (0..10)
+            .map(|x| Case::new(x, x.to_string()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_add_case() {
+    let mut cases = Cases::new();
+    cases.add_case((1, 2));
+    cases.add_case((3, 6));
+    assert_eq!(
+        cases.into_iter().collect::<Vec<_>>(),
+        vec_into![(1, 2), (3, 6)]
+    );
+}
+
+#[test]
+fn test_with_case() {
+    let cases = Cases::new().with_case((1, 2)).with_case((3, 6));
+    assert_eq!(
+        cases.into_iter().collect::<Vec<_>>(),
+        vec_into![(1, 2), (3, 6)]
+    );
+}
+
+#[test]
+fn test_len() {
+    let mut cases = Cases::default();
+    assert!(cases.is_empty());
+    assert_eq!(cases.len(), 0);
+    cases.add_case((1, 2));
+    assert!(cases.is_empty().not());
+    assert_eq!(cases.len(), 1);
+    cases.add_case((3, 6));
+    assert!(cases.is_empty().not());
+    assert_eq!(cases.len(), 2);
+}
+
+#[test]
+fn test_with_target() {
+    let inputs = 0..10;
+    let cases = inputs.with_target(|x| x * 2);
+    assert_eq!(
+        cases.into_iter().collect::<Vec<_>>(),
+        (0..10).map(|x| Case::new(x, x * 2)).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
This introduces new `Case` and `Cases` types to represent training and testing cases, with a lot of trait implementations to converting to/from both `Case` and `Cases`.

We also introduced a new `FnScorer` struct that implements `Scorer`, which now has the `Output` type as an associated type instead of a generic.

`GenomeScorer` now takes a `Scorer` instead of a "raw" `Fn` for the scoring function.

These led to a variety in other dependent files and types.